### PR TITLE
Replace dependencie python-dev with python3-dev to avoid compilation …

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,7 +3,7 @@
 #
 
 # Package dependencies
-PKG_DEPENDENCIES="python python-pip python-dev python-setuptools python-virtualenv libyaml-dev build-essential"
+PKG_DEPENDENCIES="python python-pip python3-dev python-setuptools python-virtualenv libyaml-dev build-essential"
 
 # Check if directory/file already exists (path in argument)
 myynh_check_path () {


### PR DESCRIPTION
When trying to install package I had a compilation failure. Replace dependencie python-dev to python3-dev solve the problem.