### PR TITLE
Add proxy_set_header X-scheme $scheme

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -11,6 +11,7 @@ location / {
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header Upgrade $http_upgrade;
 	proxy_set_header Connection "Upgrade";
+	proxy_set_header X-Scheme $scheme;
 
 	# Include SSOWAT user panel.
 	include conf.d/yunohost_panel.conf.inc;


### PR DESCRIPTION
After installation 403 errors with Tornado when trying to access `https://mydomain.tld` but OK with `https://myIP:5000`

Adding `proxy_set_header X-scheme $scheme` to `nginx.conf` (from octoprint doc [reverse-proxy-configuration-examples](https://community.octoprint.org/t/reverse-proxy-configuration-examples/1107)) solve the problem.